### PR TITLE
Updates error field specification

### DIFF
--- a/actions/google_sheets_insert_row_action.json
+++ b/actions/google_sheets_insert_row_action.json
@@ -108,7 +108,7 @@
       {"name": "values", "value": "[data.select{|k|/column_/ =~ k.to_s}.values.map{|v|eval(v)[:data]}]"}
     ],
     "json_api": true,
-    "error_fields": ["error", "message"],
+    "error_fields": ["error"],
     "pre_hooks": {
       "hooks": [
         {
@@ -127,7 +127,7 @@
             ],
             "remove_params": ["sheetId"],
             "json_api": true,
-            "error_fields": ["error", "message"]
+            "error_fields": ["error"]
           }
         },
         {
@@ -142,7 +142,7 @@
               {"field": "values", "value": "[data.select{|k|/column_/ =~ k.to_s}.values.map{|v|eval(v)[:label]}]", "custom": true}
             ],
             "json_api": true,
-            "error_fields": ["error", "message"]
+            "error_fields": ["error"]
           }
         }
       ]


### PR DESCRIPTION
The previous error field resulted in Pluga API interpreting the result as a retry-type-transaction whereas it should be treated as a stand-byable transaction -- logic relies on error field being of **Hash type**, not String type.

Google_sheets API, in case of error, returns a body with the following specs:

response_body = { error: { code: HTTP_STATUS_CODE, message: "descriptive error message", status: "String describing HTTP_STATUS_CODE" }

This PR makes pluga API consider the error_message the whole `response_body["error"]` structure, instead of `response_body["error"]["message"]`.